### PR TITLE
Patch RSA key size

### DIFF
--- a/src/aes/index.js
+++ b/src/aes/index.js
@@ -6,8 +6,6 @@ export const SALT_LENGTH = 12;
 export const TAG_LENGTH = 16;
 
 export class SymmetricKey {
-  static size = 256;
-
   constructor(key = null) {
     if (!key) this._key = random.getBytesSync(32);
     else this._key = util.decode64(key);

--- a/src/keys/rsa.js
+++ b/src/keys/rsa.js
@@ -33,7 +33,7 @@ export class RSAPrivateKey {
 
     const decodedBytes = util.decode64(ciphertext);
     const encryptedAESKey = decodedBytes.slice(0, modulus);
-    const message = decodedBytes.slice(SymmetricKey.size);
+    const message = decodedBytes.slice(modulus);
 
     if (!encryptedAESKey || !message) {
       throw new Error('wrong ciphertext format');


### PR DESCRIPTION
This should have been done in the last PR.. 
The size should not be hardcoded in the SymmetricKey class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-crypto/27)
<!-- Reviewable:end -->
