### PR TITLE
throw on wrong private key password

### DIFF
--- a/src/tests/pke.test.js
+++ b/src/tests/pke.test.js
@@ -57,6 +57,16 @@ describe('Encryption', () => {
           expect(key.export()).toBe(v.priv);
         });
 
+        it('should fail to load private key when password is wrong', () => {
+          expect(
+            () =>
+              new EncryptionPrivateKey({
+                pemPrivateKey: v.encPriv,
+                password: 'bad'
+              })
+          ).toThrow('could not decode private key: wrong password');
+        });
+
         it('should export encrypted key', () => {
           const key = new EncryptionPrivateKey({ algo: k });
           const enc = key.export(cases.password);

--- a/src/utils/encoding.js
+++ b/src/utils/encoding.js
@@ -126,7 +126,16 @@ export const decodePrivateKey = (pemPrivateKey, password = null) => {
   let keyInfo;
   const msg = pem.decode(pemPrivateKey)[0];
   if (password) {
-    keyInfo = pki.decryptPrivateKeyInfo(asn1.fromDer(msg.body), password);
+    try {
+      // 'decryptPrivateKeyInfo' can either throw an exception
+      // or return null if the password is wrong.
+      keyInfo = pki.decryptPrivateKeyInfo(asn1.fromDer(msg.body), password);
+      if (!keyInfo) {
+        throw new Error('wrong password');
+      }
+    } catch (err) {
+      throw new Error('could not decode private key: wrong password');
+    }
   } else {
     if (msg.procType && msg.procType.type === 'ENCRYPTED') {
       throw new Error(


### PR DESCRIPTION
node forge's  `pki.decryptPrivateKeyInfo` can throw different exceptions when the password is wrong (depending on the password length apparently), but it can also return a `null`  value indicating that the password is wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-crypto/29)
<!-- Reviewable:end -->
