### PR TITLE
New: Add option to generate encryption keys asynchronously

### DIFF
--- a/src/keys/rsa.js
+++ b/src/keys/rsa.js
@@ -8,9 +8,22 @@ import { bytesToString } from '../utils';
 // ============================================================================
 
 export class RSAPrivateKey {
-  constructor(key = null) {
-    if (!key) this.generate();
-    else this._key = key;
+  static generateAsync = () =>
+    new Promise((resolve, reject) => {
+      rsa.generateKeyPair(
+        { bits: 2048, workers: -1 },
+        (err, { privateKey }) => {
+          if (err) return reject(err);
+          const key = new RSAPrivateKey(null, false);
+          key._key = privateKey;
+          return resolve(key);
+        }
+      );
+    });
+
+  constructor(key = null, generate = true) {
+    if (key) this._key = key;
+    else if (generate) this.generate();
   }
 
   generate = () => {

--- a/src/pke/keyPair.js
+++ b/src/pke/keyPair.js
@@ -11,7 +11,7 @@ export default class EncryptionKeyPair {
   constructor(opts) {
     // opts can contain either pemPrivateKey and password to load a key
     // or algo to generate a new one. It can also forgo key generation
-    // to use the more preformant async option.
+    // to use the more performant async option.
     if (opts.generate !== false) {
       this._privateKey = new EncryptionPrivateKey(opts);
       this._publicKey = this._privateKey.publicKey();

--- a/src/pke/keyPair.js
+++ b/src/pke/keyPair.js
@@ -1,11 +1,21 @@
 import EncryptionPrivateKey from './privateKey';
 
 export default class EncryptionKeyPair {
+  static generateAsync = async algo => {
+    const keyPair = new EncryptionKeyPair({ generate: false });
+    keyPair._privateKey = await EncryptionPrivateKey.generateAsync(algo);
+    keyPair._publicKey = keyPair._privateKey.publicKey();
+    return keyPair;
+  };
+
   constructor(opts) {
-    // opts should contain either pemPrivateKey and password to load a key
-    // or algo to generate a new one.
-    this._privateKey = new EncryptionPrivateKey(opts);
-    this._publicKey = this._privateKey.publicKey();
+    // opts can contain either pemPrivateKey and password to load a key
+    // or algo to generate a new one. It can also forgo key generation
+    // to use the more preformant async option.
+    if (opts.generate !== false) {
+      this._privateKey = new EncryptionPrivateKey(opts);
+      this._publicKey = this._privateKey.publicKey();
+    }
   }
 
   get private() {

--- a/src/pke/privateKey.js
+++ b/src/pke/privateKey.js
@@ -5,10 +5,23 @@ import { PKE_ALGO_RSA } from './constants';
 import { encodePrivateKeyInfo, decodePrivateKey } from '../utils/encoding';
 
 export default class EncryptionPrivateKey {
-  constructor({ algo, pemPrivateKey, password }) {
+  static generateAsync = async algo => {
+    const privateKey = new EncryptionPrivateKey({ generate: false });
+    privateKey._algo = algo;
+    switch (algo) {
+      case PKE_ALGO_RSA.name: {
+        privateKey._key = await RSAPrivateKey.generateAsync();
+        return privateKey;
+      }
+      default:
+        throw new Error(`Unsupported encryption algorithm "${algo}"`);
+    }
+  };
+
+  constructor({ algo, pemPrivateKey, password, generate = true }) {
     if (pemPrivateKey) {
       this.load(pemPrivateKey, password);
-    } else {
+    } else if (generate) {
       this.generate(algo);
     }
   }

--- a/src/tests/pke.test.js
+++ b/src/tests/pke.test.js
@@ -16,6 +16,12 @@ describe('Encryption', () => {
           expect(kp.public).not.toBeFalsy();
         });
 
+        it('should generate asynchronously', async () => {
+          const kp = await EncryptionKeyPair.generateAsync(k);
+          expect(kp.private).not.toBeFalsy();
+          expect(kp.public).not.toBeFalsy();
+        });
+
         it('should load private key', () => {
           const kp = new EncryptionKeyPair({ pemPrivateKey: v.priv });
           expect(kp.private.export()).toBe(v.priv);


### PR DESCRIPTION
This PR adds some static methods to generate keys asynchronously. I added to this to fix a performance issue in the browser. When creating RSA keys synchronously the UI would freeze. node-forge recommends using async key generation to avoid blocking. This changes adds this functionality without introducing any breaking changes.

https://www.npmjs.com/package/node-forge#rsa

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-crypto/35)
<!-- Reviewable:end -->
