### PR TITLE
Update: AES: Direct binary enrypt/decrypt (BTA-159)

### DIFF
--- a/src/aes/index.js
+++ b/src/aes/index.js
@@ -6,7 +6,7 @@ export const SALT_LENGTH = 12;
 export const TAG_LENGTH = 16;
 
 export const CIPHERTEXT_ENCODING_BIN = 'binary';
-export const CIPHERTEXT_ENCODING_B64 = CIPHERTEXT_ENCODING_B64;
+export const CIPHERTEXT_ENCODING_B64 = 'base64';
 
 export class SymmetricKey {
   constructor(key = null) {

--- a/src/tests/aes.test.js
+++ b/src/tests/aes.test.js
@@ -9,13 +9,24 @@ describe('SymmetricKey', () => {
   Object.entries(cases.aes).forEach(([k, v]) => {
     describe(k, () => {
       describe('encryption', () => {
-        it('encrypts a message', () => {
+        it('encrypts a message to base64', () => {
           const key = new SymmetricKey(v.key);
           const msg = 'plap';
 
           const ciphertext = key.encrypt(msg);
-          const plaintext = key.decrypt(ciphertext);
-          expect(plaintext).toBe(msg);
+          const ctBinary = Buffer.from(ciphertext, 'base64').toString('binary');
+          expect(key.decrypt(ciphertext)).toBe(msg);
+          expect(key.decrypt(ctBinary, 'utf8', 'binary')).toBe(msg);
+        });
+
+        it('encrypts a message to binary', () => {
+          const key = new SymmetricKey(v.key);
+          const msg = 'plap';
+
+          const ciphertext = key.encrypt(msg, 'utf8', 'binary');
+          const ctB64 = Buffer.from(ciphertext, 'binary').toString('base64');
+          expect(key.decrypt(ciphertext, 'utf8', 'binary')).toBe(msg);
+          expect(key.decrypt(ctB64)).toBe(msg);
         });
 
         it('supports utf-8 characters', () => {
@@ -34,7 +45,10 @@ describe('SymmetricKey', () => {
           readFile(path.resolve(__dirname, file), (err, data) => {
             expect(err).toBe(null);
             const ciphertext = key.encrypt(data, 'binary');
-            const plaintext = key.decrypt(ciphertext, 'binary');
+            const plaintext = Buffer.from(
+              key.decrypt(ciphertext, 'binary'),
+              'binary'
+            );
             expect(plaintext).toEqual(data);
             done();
           });
@@ -42,9 +56,20 @@ describe('SymmetricKey', () => {
       });
 
       describe('decryption', () => {
-        it('decrypts a message', () => {
+        it('decrypts a message from base64', () => {
           const key = new SymmetricKey(v.key);
           const encrypted = key.decrypt(v.ciphertext);
+
+          expect(encrypted).toEqual(cases.message);
+        });
+
+        it('decrypts a message from binary', () => {
+          const key = new SymmetricKey(v.key);
+          const encrypted = key.decrypt(
+            Buffer.from(v.ciphertext, 'base64'),
+            'utf8',
+            'binary'
+          );
 
           expect(encrypted).toEqual(cases.message);
         });

--- a/src/tests/aes.test.js
+++ b/src/tests/aes.test.js
@@ -3,7 +3,12 @@ import path from 'path';
 import { util, random } from 'node-forge';
 
 import cases from './cases.json';
-import { SymmetricKey, SALT_LENGTH, TAG_LENGTH } from '../aes';
+import {
+  SymmetricKey,
+  SALT_LENGTH,
+  TAG_LENGTH,
+  CIPHERTEXT_ENCODING_BIN
+} from '../aes';
 
 describe('SymmetricKey', () => {
   Object.entries(cases.aes).forEach(([k, v]) => {
@@ -14,18 +19,27 @@ describe('SymmetricKey', () => {
           const msg = 'plap';
 
           const ciphertext = key.encrypt(msg);
-          const ctBinary = Buffer.from(ciphertext, 'base64').toString('binary');
+          const ctBinary = Buffer.from(ciphertext, 'base64').toString(
+            CIPHERTEXT_ENCODING_BIN
+          );
           expect(key.decrypt(ciphertext)).toBe(msg);
-          expect(key.decrypt(ctBinary, 'utf8', 'binary')).toBe(msg);
+          expect(key.decrypt(ctBinary, 'utf8', CIPHERTEXT_ENCODING_BIN)).toBe(
+            msg
+          );
         });
 
         it('encrypts a message to binary', () => {
           const key = new SymmetricKey(v.key);
           const msg = 'plap';
 
-          const ciphertext = key.encrypt(msg, 'utf8', 'binary');
-          const ctB64 = Buffer.from(ciphertext, 'binary').toString('base64');
-          expect(key.decrypt(ciphertext, 'utf8', 'binary')).toBe(msg);
+          const ciphertext = key.encrypt(msg, 'utf8', CIPHERTEXT_ENCODING_BIN);
+          const ctB64 = Buffer.from(
+            ciphertext,
+            CIPHERTEXT_ENCODING_BIN
+          ).toString('base64');
+          expect(key.decrypt(ciphertext, 'utf8', CIPHERTEXT_ENCODING_BIN)).toBe(
+            msg
+          );
           expect(key.decrypt(ctB64)).toBe(msg);
         });
 
@@ -44,10 +58,10 @@ describe('SymmetricKey', () => {
           const file = './fixtures/testPicture.jpg';
           readFile(path.resolve(__dirname, file), (err, data) => {
             expect(err).toBe(null);
-            const ciphertext = key.encrypt(data, 'binary');
+            const ciphertext = key.encrypt(data, CIPHERTEXT_ENCODING_BIN);
             const plaintext = Buffer.from(
-              key.decrypt(ciphertext, 'binary'),
-              'binary'
+              key.decrypt(ciphertext, CIPHERTEXT_ENCODING_BIN),
+              CIPHERTEXT_ENCODING_BIN
             );
             expect(plaintext).toEqual(data);
             done();
@@ -68,7 +82,7 @@ describe('SymmetricKey', () => {
           const encrypted = key.decrypt(
             Buffer.from(v.ciphertext, 'base64'),
             'utf8',
-            'binary'
+            CIPHERTEXT_ENCODING_BIN
           );
 
           expect(encrypted).toEqual(cases.message);

--- a/src/tests/cases.json
+++ b/src/tests/cases.json
@@ -27,7 +27,8 @@
   "aes": {
     "GCM": {
       "key": "dXRdc1KYm8DVFFxc0Hq65ZVoZvHAD/PBx0GUgSMmPEw=",
-      "ciphertext": "FfogaZ5Wy4oDfCDqQQUtciiZf/6CsZxrBQr2ZHVswimxB7IwQw9Z8brNocu3O5q1DKYaP4cBmzcPi++1mE4="
+      "ciphertext": "FfogaZ5Wy4oDfCDqQQUtciiZf/6CsZxrBQr2ZHVswimxB7IwQw9Z8brNocu3O5q1DKYaP4cBmzcPi++1mE4=",
+      "ciphertextBinary": "FfogaZ5Wy4oDfCDqQQUtciiZf/6CsZxrBQr2ZHVswimxB7IwQw9Z8brNocu3O5q1DKYaP4cBmzcPi++1mE4="
     }
   }
 }

--- a/src/tests/pke.test.js
+++ b/src/tests/pke.test.js
@@ -125,8 +125,8 @@ describe('Encryption', () => {
           const sk = new EncryptionPrivateKey({ pemPrivateKey: v.priv });
           const msg = 'plap';
 
-          const ciphertext = pk.encrypt(msg);
-          const plaintext = sk.decrypt(ciphertext);
+          const ciphertext = pk.encryptShort(msg);
+          const plaintext = sk.decryptShort(ciphertext);
           expect(plaintext).toBe(msg);
         });
       });


### PR DESCRIPTION
In the case of file encryption, we nee the binary data. Which means that right now, there is a useless round of encoding + decoding. For big files, this is breaking the browser...
In order to avoid that, we let the user choose the input and output encoding for AES encryption and decryption.

note: in the case of decryption, we still need to go through a round of decoding... This is due to the fact that forge encode the result as a binary string. In order foe that operation to be efficient, we broke down the decrypted data into smaller blocks and then concatenate them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stratumn/js-crypto/38)
<!-- Reviewable:end -->
